### PR TITLE
Fix boolean check to work with new Type::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Bool type checks now work properly with Type::Tiny 1.004000 and later.
+
+
 0.03     2016-04-04
 
 - Added a new WebService::TeamCity::Entity::Build->artifacts_dir method. This

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can pass arguments as key/value pairs to limit the build types returned:
 
     Only return build types matching this name.
 
-- paused => Bool
+- paused => Bool | JSONBool
 
     Only return build types which are or are not paused.
 
@@ -134,7 +134,7 @@ You can pass arguments as key/value pairs to limit the build types returned:
     defined the same way as a build type, but you cannot include a `template` key
     for the template spec too.
 
-- template\_flag => Bool
+- template\_flag => Bool | JSONBool
 
     Only return build types which are or are not templates.
 
@@ -164,11 +164,11 @@ You can pass arguments as key/value pairs to limit the projects returned:
     Only return builds which were built using the specific build type. Build types
     can be specified as defined for the `build_types` method.
 
-- canceled => Bool
+- canceled => Bool | JSONBool
 
     Only returns builds which were or were not canceled.
 
-- failed\_to\_start => Bool
+- failed\_to\_start => Bool | JSONBool
 
     Only returns builds which did or did not fail to start.
 
@@ -188,11 +188,11 @@ You can pass arguments as key/value pairs to limit the projects returned:
 
     Only return builds matching this number.
 
-- personal => Bool
+- personal => Bool | JSONBool
 
     Only returns builds which are or are not marked as personal builds.
 
-- pinned => Bool
+- pinned => Bool | JSONBool
 
     Only returns builds which are or are not pinned.
 
@@ -202,7 +202,7 @@ You can pass arguments as key/value pairs to limit the projects returned:
     specified as defined for the `projects` method. This only includes the
     project itself, not its sub-projects.
 
-- running => Bool
+- running => Bool | JSONBool
 
     Only returns builds which are or are not running.
 

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,7 @@ pod_coverage_skip = WebService::TeamCity::Types
 pod_coverage_skip = qr/^WebService::TeamCity::Entity::Has.+/
 ; Only used in the fixture generator code
 prereqs_skip = Path::Class
+stopwords = JSONBool
 stopwords = Str
 stopwords = ua
 -remove = Test::Portability

--- a/lib/WebService/TeamCity.pm
+++ b/lib/WebService/TeamCity.pm
@@ -14,7 +14,15 @@ use LWP::UserAgent;
 use String::CamelSnakeKebab qw( lower_snake_case );
 use Try::Tiny;
 use Type::Utils qw( class_type );
-use Types::Standard qw( ArrayRef Bool Dict InstanceOf Int Optional Str );
+use Types::Standard qw(
+    ArrayRef
+    Bool
+    Dict
+    InstanceOf
+    Int
+    Optional
+    Str
+);
 use URI::FromHash qw( uri_object );
 use URI::QueryParam;
 use URI;
@@ -23,7 +31,7 @@ use WebService::TeamCity::Entity::BuildType;
 use WebService::TeamCity::Iterator;
 use WebService::TeamCity::LocatorSpec;
 use WebService::TeamCity::Entity::Project;
-use WebService::TeamCity::Types qw( BuildStatus DateTimeObject );
+use WebService::TeamCity::Types qw( BuildStatus DateTimeObject JSONBool );
 
 use Moo;
 
@@ -135,15 +143,15 @@ sub build_types {
                 agent_name       => Str,
                 branch           => Str,
                 build_type       => $self->_build_type_locator_spec,
-                canceled         => Bool,
-                failed_to_start  => Bool,
+                canceled         => Bool | JSONBool,
+                failed_to_start  => Bool | JSONBool,
                 id               => Str,
                 lookup_limit     => Int,
                 number           => Int,
-                personal         => Bool,
-                pinned           => Bool,
+                personal         => Bool | JSONBool,
+                pinned           => Bool | JSONBool,
                 project          => $project_spec,
-                running          => Bool,
+                running          => Bool | JSONBool,
                 since_date       => DateTimeObject,
                 status           => BuildStatus,
                 tags             => ArrayRef [Str],
@@ -180,9 +188,9 @@ sub build_types {
                 affected_project => $project_spec,
                 id               => Str,
                 name             => Str,
-                paused           => Bool,
+                paused           => Bool | JSONBool,
                 project          => $project_spec,
-                template_flag    => Bool,
+                template_flag    => Bool | JSONBool,
             );
 
             # We're not going to allow arbitrarily nested template build
@@ -439,7 +447,7 @@ Only return build types matching this id.
 
 Only return build types matching this name.
 
-=item * paused => Bool
+=item * paused => Bool | JSONBool
 
 Only return build types which are or are not paused.
 
@@ -455,7 +463,7 @@ Only return build types which use the specified template. The template is
 defined the same way as a build type, but you cannot include a C<template> key
 for the template spec too.
 
-=item * template_flag => Bool
+=item * template_flag => Bool | JSONBool
 
 Only return build types which are or are not templates.
 
@@ -489,11 +497,11 @@ Only return builds which were built against the specified branch.
 Only return builds which were built using the specific build type. Build types
 can be specified as defined for the C<build_types> method.
 
-=item * canceled => Bool
+=item * canceled => Bool | JSONBool
 
 Only returns builds which were or were not canceled.
 
-=item * failed_to_start => Bool
+=item * failed_to_start => Bool | JSONBool
 
 Only returns builds which did or did not fail to start.
 
@@ -513,11 +521,11 @@ Only return builds matching this name.
 
 Only return builds matching this number.
 
-=item * personal => Bool
+=item * personal => Bool | JSONBool
 
 Only returns builds which are or are not marked as personal builds.
 
-=item * pinned => Bool
+=item * pinned => Bool | JSONBool
 
 Only returns builds which are or are not pinned.
 
@@ -527,7 +535,7 @@ Only return builds which affect the specified project. Projects can be
 specified as defined for the C<projects> method. This only includes the
 project itself, not its sub-projects.
 
-=item * running => Bool
+=item * running => Bool | JSONBool
 
 Only returns builds which are or are not running.
 

--- a/lib/WebService/TeamCity/Entity/Build.pm
+++ b/lib/WebService/TeamCity/Entity/Build.pm
@@ -14,7 +14,7 @@ use Types::Standard qw( ArrayRef Bool Maybe InstanceOf Str );
 use WebService::TeamCity::Entity::BuildType;
 use WebService::TeamCity::Iterator;
 use WebService::TeamCity::Entity::TestOccurrence;
-use WebService::TeamCity::Types qw( BuildStatus );
+use WebService::TeamCity::Types qw( BuildStatus JSONBool );
 
 use Moo;
 
@@ -58,7 +58,7 @@ has branch_name => (
 
 has default_branch => (
     is        => 'ro',
-    isa       => Bool,
+    isa       => Bool | JSONBool,
     predicate => 'has_default_branch',
 );
 

--- a/lib/WebService/TeamCity/Entity/HasStatus.pm
+++ b/lib/WebService/TeamCity/Entity/HasStatus.pm
@@ -8,6 +8,7 @@ use namespace::autoclean;
 our $VERSION = '0.04';
 
 use Types::Standard qw( Bool );
+use WebService::TeamCity::Types qw( JSONBool );
 
 use Moo::Role;
 
@@ -15,14 +16,14 @@ requires 'status';
 
 has passed => (
     is      => 'ro',
-    isa     => Bool,
+    isa     => Bool | JSONBool,
     lazy    => 1,
     default => sub { $_[0]->status eq 'SUCCESS' },
 );
 
 has failed => (
     is      => 'ro',
-    isa     => Bool,
+    isa     => Bool | JSONBool,
     lazy    => 1,
     default => sub { $_[0]->status eq 'FAILURE' },
 );

--- a/lib/WebService/TeamCity/Entity/Project.pm
+++ b/lib/WebService/TeamCity/Entity/Project.pm
@@ -10,12 +10,13 @@ our $VERSION = '0.04';
 use Types::Standard qw( ArrayRef Bool InstanceOf Maybe Str );
 use WebService::TeamCity::Entity::BuildType;
 use WebService::TeamCity::Entity::Project;
+use WebService::TeamCity::Types qw( JSONBool );
 
 use Moo;
 
 has archived => (
     is      => 'ro',
-    isa     => Bool,
+    isa     => Bool | JSONBool,
     default => 0,
 );
 

--- a/lib/WebService/TeamCity/Entity/TestOccurrence.pm
+++ b/lib/WebService/TeamCity/Entity/TestOccurrence.pm
@@ -9,6 +9,7 @@ our $VERSION = '0.04';
 
 use Types::Standard qw( Bool InstanceOf Int Str );
 use WebService::TeamCity::Types qw( TestStatus );
+use WebService::TeamCity::Types qw( JSONBool );
 
 use Moo;
 
@@ -38,7 +39,7 @@ has build => (
 
 has unknown => (
     is      => 'ro',
-    isa     => Bool,
+    isa     => Bool | JSONBool,
     lazy    => 1,
     default => sub { $_[0]->status eq 'UNKNOWN' },
 );

--- a/lib/WebService/TeamCity/LocatorSpec.pm
+++ b/lib/WebService/TeamCity/LocatorSpec.pm
@@ -8,9 +8,18 @@ use namespace::autoclean;
 our $VERSION = '0.04';
 
 use Type::Params qw( compile );
-use Types::Standard qw( ArrayRef Bool Dict HashRef Int Optional Str slurpy );
+use Types::Standard qw(
+    ArrayRef
+    Bool
+    Dict
+    HashRef
+    Int
+    Optional
+    Str
+    slurpy
+);
 use String::CamelSnakeKebab qw( lower_camel_case );
-use WebService::TeamCity::Types qw( DateTimeObject );
+use WebService::TeamCity::Types qw( DateTimeObject JSONBool );
 
 use Moo;
 
@@ -85,7 +94,7 @@ sub locator_string_for_args {
                 search_args => $args{search_args}{$key} )
                 . ')';
         }
-        elsif ( $type->equals(Bool) ) {
+        elsif ( $type->equals( Bool | JSONBool ) ) {
             $v = $args{search_args}{$key} ? 'true' : 'false';
         }
         elsif ( $type->is_subtype_of(ArrayRef) ) {

--- a/lib/WebService/TeamCity/Types.pm
+++ b/lib/WebService/TeamCity/Types.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.04';
 use Type::Library
     -base,
     -declare => qw( BuildStatus DateTimeObject JSONBool TestStatus );
-use Type::Utils qw( class_type enum );
+use Type::Utils qw( class_type enum union );
 
 enum BuildStatus, [qw( SUCCESS FAILURE ERROR UNKNOWN )];
 
@@ -16,6 +16,9 @@ enum TestStatus, [qw( SUCCESS FAILURE UNKNOWN )];
 
 class_type DateTimeObject, { class => 'DateTime' };
 
-class_type JSONBool, { class => 'JSON::PP::Boolean' };
+union JSONBool, [
+    class_type('JSON::PP::Boolean'),
+    class_type('JSON::XS::Boolean'),
+];
 
 1;

--- a/lib/WebService/TeamCity/Types.pm
+++ b/lib/WebService/TeamCity/Types.pm
@@ -7,7 +7,7 @@ our $VERSION = '0.04';
 
 use Type::Library
     -base,
-    -declare => qw( BuildStatus DateTimeObject TestStatus );
+    -declare => qw( BuildStatus DateTimeObject JSONBool TestStatus );
 use Type::Utils qw( class_type enum );
 
 enum BuildStatus, [qw( SUCCESS FAILURE ERROR UNKNOWN )];
@@ -15,5 +15,7 @@ enum BuildStatus, [qw( SUCCESS FAILURE ERROR UNKNOWN )];
 enum TestStatus, [qw( SUCCESS FAILURE UNKNOWN )];
 
 class_type DateTimeObject, { class => 'DateTime' };
+
+class_type JSONBool, { class => 'JSON::PP::Boolean' };
 
 1;


### PR DESCRIPTION
This is due to the change from https://github.com/tobyink/p5-type-tiny-xs/issues/5

Previously, these type checks would have also failed with
Type::Tiny::XS.